### PR TITLE
Update version, compatible releases

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -41,11 +41,11 @@ The following table provides version and version-support information about Signa
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.0.0</td>
+        <td>v1.0.1</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>March 9, 2018</td>
+        <td>February 12, 2019</td>
     </tr>
     <tr>
         <td>Software component version</td>
@@ -53,15 +53,11 @@ The following table provides version and version-support information about Signa
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.11.x, v1.12.x, and v2.0.x</td>
+        <td>v2.1.x, v2.2.x, v2.3.x, v2.4.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>v1.11.x, v1.12.x, and v2.0.x</td>
-    </tr>
-    <tr>
-        <td>IaaS support</td>
-        <td>AWS, GCP, vSphere, Azure, and OpenStack </td>
+        <td>v2.1.x, v2.2.x, v2.3.x, v2.4.x</td>
     </tr>
 </table>
 

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -53,11 +53,11 @@ The following table provides version and version-support information about Signa
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v2.1.x, v2.2.x, v2.3.x, v2.4.x</td>
+        <td>v2.1.x, v2.2.x, v2.3.x, and v2.4.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>v2.1.x, v2.2.x, v2.3.x, v2.4.x</td>
+        <td>v2.1.x, v2.2.x, v2.3.x, and v2.4.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -41,11 +41,11 @@ The following table provides version and version-support information about Signa
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.0.1</td>
+        <td>v1.0.4</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>February 12, 2019</td>
+        <td>February 20, 2019</td>
     </tr>
     <tr>
         <td>Software component version</td>
@@ -58,6 +58,10 @@ The following table provides version and version-support information about Signa
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
         <td>v2.1.x, v2.2.x, v2.3.x, v2.4.x</td>
+    </tr>
+    <tr>
+        <td>Compatible Stemcell(s)</td>
+        <td>170, or any 64-bit linux-based distribution</td>
     </tr>
 </table>
 

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -60,8 +60,8 @@ The following table provides version and version-support information about Signa
         <td>v2.1.x, v2.2.x, v2.3.x, v2.4.x</td>
     </tr>
     <tr>
-        <td>Compatible Stemcell(s)</td>
-        <td>170, or any 64-bit linux-based distribution</td>
+        <td>IaaS support</td>
+        <td>AWS, GCP, vSphere, Azure, and OpenStack </td>
     </tr>
 </table>
 


### PR DESCRIPTION
This version (1.0.4) has not been tested on any pre-2.1 Ops Manager or PAS installations, so removing those listed versions and adding 2.1-2.4.