### PR TITLE
Remove outdated warning about version 1.0.0

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -66,13 +66,6 @@ The following table provides version and version-support information about Signa
         <td>AWS, GCP, vSphere, Azure, and OpenStack </td>
     </tr>
 </table>
-<p class="note warning"><strong> WARNING:</strong>
-Signal Sciences Service Broker for PCF v1.0.0
-and earlier require a Ubuntu Trusty stemcell.
-The end-of-life date for Ubuntu Trusty is April 2019.
-If a security vulnerability is found on this stemcell after April, it will not be fixed.</p>
-
-
 
 ## <a id="reqs"></a>Requirements
 

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -66,6 +66,14 @@ The following table provides version and version-support information about Signa
         <td>AWS, GCP, vSphere, Azure, and OpenStack </td>
     </tr>
 </table>
+<p class="note warning"><strong> WARNING:</strong>
+The previous version (v1.0.0)
+and earlier require a Ubuntu Trusty stemcell.
+The end-of-life date for Ubuntu Trusty is April 2019.
+If a security vulnerability is found on this stemcell after April, it will not be fixed.
+It is advised to upgrade to the latest version as soon as possible.</p>
+
+
 
 ## <a id="reqs"></a>Requirements
 


### PR DESCRIPTION
Version 1.0.4 works with current stemcells.